### PR TITLE
Add Documentation button, fix contributor link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,9 +11,13 @@ blocks:
   # TODO: Get the resource bundles sorted
   # image: images/logo/template-library.png
   buttons:
-  - text: How to contribute
-    url: "https://github.com/wiremock/api-template-library/blob/main/docs/CONTRIBUTING.md"
+  - text: Documentation
+    url: "https://wiremock.org/docs/mock-api-templates/usage/"
     style: primary
+    size: large
+  - text: How to contribute
+    url: "./how-to-contribute"
+    style: secondary
     size: large
 ---
 


### PR DESCRIPTION
Depends on 

### Screenshot

![image](https://github.com/wiremock/library.wiremock.org-sources/assets/3000480/488bb6a5-4128-44a7-a4e9-f8aeeefc08d8)
